### PR TITLE
Fixed StringStream readBytes method not working to read a single byte.

### DIFF
--- a/src/StreamUtils/Streams/StringStream.hpp
+++ b/src/StreamUtils/Streams/StringStream.hpp
@@ -59,7 +59,10 @@ class StringStream : public Stream {
   size_t readBytes(char* buffer, size_t length) override {
     if (length > _str.length())
       length = _str.length();
-    _str.toCharArray(buffer, length);
+    if (length == 1)
+      *buffer = _str.charAt(0);
+    else
+      _str.toCharArray(buffer, length);
     _str.remove(0, length);
     return length;
   }


### PR DESCRIPTION
This is important when using the ArduinoJson library, as it eschews the read() method in favor of reading a single byte with a readBytes call.

fixes issue #16 