### PR TITLE
STM32 Buffered EEPROM

### DIFF
--- a/src/StreamUtils/Streams/EepromStream.hpp
+++ b/src/StreamUtils/Streams/EepromStream.hpp
@@ -35,6 +35,9 @@ class EepromStream : public Stream {
   }
 
   void flush() override {
+#if ARDUINO_ARCH_STM32
+    eeprom_buffer_flush();
+#endif
 #if STREAMUTILS_USE_EEPROM_COMMIT
     EEPROM.commit();
 #endif
@@ -51,7 +54,11 @@ class EepromStream : public Stream {
 #if STREAMUTILS_USE_EEPROM_UPDATE
       EEPROM.update(address, buffer[i]);
 #else
+#if ARDUINO_ARCH_STM32
+      eeprom_buffered_write_byte(address, buffer[i]);
+#else
       EEPROM.write(address, buffer[i]);
+#endif
 #endif
     }
     return size;
@@ -64,7 +71,11 @@ class EepromStream : public Stream {
 #if STREAMUTILS_USE_EEPROM_UPDATE
     EEPROM.update(address, data);
 #else
-    EEPROM.write(address, data);
+#if ARDUINO_ARCH_STM32
+      eeprom_buffered_write_byte(address, data);
+#else
+      EEPROM.write(address, data);
+#endif
 #endif
     return 1;
   }


### PR DESCRIPTION
I found the eeprom write slow, which was a known fact due to the EEPROM emulation in the official STM32 core.
I have found using the buffered write and flush methods resolves this problem.
I am not intending this to be the final solution, as my tests have been succesful but minimul in nature.

Happy to help to get this merged if you feel it is helpful for others.

I haven't found the read an issue, maybe ```eeprom_buffered_read_byte``` should be used as well?